### PR TITLE
Expand chord_quality with common chord types and aliases

### DIFF
--- a/tonal/notes.py
+++ b/tonal/notes.py
@@ -368,9 +368,25 @@ chord_quality: dict[str, Sequence[int]] = {
     # Suspended chords
     "sus": (0, 5, 7),  # Sus4
     "sus2": (0, 2, 7),
+    "7sus4": (0, 5, 7, 10),  # Dominant 7th suspended 4th
     # Added-tone chords
     "add9": (0, 4, 7, 14),
     "add2": (0, 2, 4, 7),
+    "6add9": (0, 4, 7, 9, 14),  # 6/9 chord (major 6 add 9)
+    "minadd9": (0, 3, 7, 14),  # Minor add 9
+    "min6add9": (0, 3, 7, 9, 14),  # Minor 6/9
+    "minmaj9": (0, 3, 7, 11, 14),  # Minor major 9th
+    # Power chord
+    "5": (0, 7),  # Power chord (root + fifth)
+    # Altered-fifth chords
+    "maj7b5": (0, 4, 6, 11),  # Major 7th flat 5
+    "maj7#5": (0, 4, 8, 11),  # Augmented major 7th (major 7 sharp 5)
+    "7b5": (0, 4, 6, 10),  # Dominant 7th flat 5
+    "min11b5": (0, 3, 6, 10, 14, 17),  # Minor 11th flat 5
+    # Altered-extension dominants
+    "7b9": (0, 4, 7, 10, 13),  # Dominant 7th flat 9
+    "7#9": (0, 4, 7, 10, 15),  # Dominant 7th sharp 9 (Hendrix chord)
+    "7alt": (0, 4, 8, 10, 13, 15),  # Altered dominant (3, #5/b13, b7, b9, #9)
 }
 
 # Common textual shorthands (e.g. Dm11) used by some lead sheets
@@ -383,6 +399,14 @@ _text_chord_quality_aliases: dict[str, str] = {
     "m7b5": "hdim7",
     "min7b5": "hdim7",
     "ø7": "hdim7",
+    "ø": "hdim7",  # bare half-diminished symbol
+    "sus4": "sus",  # explicit Sus4 spelling
+    "mmaj7": "minmaj7",  # Minor major 7th
+    "mmaj9": "minmaj9",  # Minor major 9th
+    "madd9": "minadd9",  # Minor add 9
+    "m6add9": "min6add9",  # Minor 6/9
+    "m11b5": "min11b5",  # Minor 11th flat 5
+    "7#5": "aug7",  # Dominant augmented 7th (same intervals as aug7)
 }
 
 for _alias, _canonical in _text_chord_quality_aliases.items():

--- a/tonal/tests/test_chords.py
+++ b/tonal/tests/test_chords.py
@@ -32,7 +32,16 @@ def test_chord_to_notes_ignores_slash_bass_note():
 
 
 def test_chord_to_notes_simplifies_common_alterations():
-    """Common alterations should not cause failures (base quality is used)."""
-    notes = chord_to_notes("A7b9")
+    """Undefined alterations fall back to the base quality (suffix stripped)."""
+    # 7#11 is not a defined quality, so it strips to a plain dominant 7th.
+    notes = chord_to_notes("A7#11")
     assert len(notes) == 4
     assert notes[3] - notes[0] == 10  # dominant 7th
+
+
+def test_chord_to_notes_honors_defined_alterations():
+    """Alterations that are defined qualities are honored, not stripped."""
+    notes = chord_to_notes("A7b9")
+    assert len(notes) == 5
+    root = notes[0]
+    assert tuple(n - root for n in notes) == (0, 4, 7, 10, 13)  # dominant 7th flat 9


### PR DESCRIPTION
## Summary

Expands `chord_quality` in `tonal/notes.py` so the full set of common chord types resolves. Each missing type was added in one of two ways, following the existing design:

- **New base interval pattern** when it's a genuinely new chord shape.
- **Alias** (in `_text_chord_quality_aliases`) when an equivalent already existed under a different name — i.e. we just identified an alternate spelling.

## New base patterns

| key | intervals | name |
|---|---|---|
| `7sus4` | `(0,5,7,10)` | Dominant 7th suspended 4th |
| `6add9` | `(0,4,7,9,14)` | 6/9 chord |
| `maj7b5` | `(0,4,6,11)` | Major 7th ♭5 |
| `maj7#5` | `(0,4,8,11)` | Augmented major 7th |
| `7b5` | `(0,4,6,10)` | Dominant 7th ♭5 |
| `7b9` | `(0,4,7,10,13)` | Dominant 7th ♭9 |
| `7#9` | `(0,4,7,10,15)` | Dominant 7th ♯9 (Hendrix) |
| `5` | `(0,7)` | Power chord |
| `minadd9` | `(0,3,7,14)` | Minor add 9 |
| `min6add9` | `(0,3,7,9,14)` | Minor 6/9 |
| `minmaj9` | `(0,3,7,11,14)` | Minor major 9th |
| `min11b5` | `(0,3,6,10,14,17)` | Minor 11th ♭5 |
| `7alt` | `(0,4,8,10,13,15)` | Altered dominant |

## New aliases (alternate names for existing patterns)

`sus4`→`sus`, `mmaj7`→`minmaj7`, `mmaj9`→`minmaj9`, `madd9`→`minadd9`, `m6add9`→`min6add9`, `m11b5`→`min11b5`, `7#5`→`aug7`, and **`ø`→`hdim7`** (bare half-diminished symbol, alongside the existing `ø7`).

## Rationale of choices

- **Base vs. alias split.** Per the request, anything whose intervals already existed under another name became an alias rather than a duplicate base entry. The clearest case is `7#5`, whose `(0,4,8,10)` is identical to the existing `aug7` — so it's an alias, not a new pattern. Same for `sus4` (= `sus`) and `mmaj7` (= `minmaj7`).
- **Minor-extended naming convention.** The dict already encodes minor chords with a full `min*` base key and a `m*` text alias (e.g. base `min7`, alias `m7`). New minor-extended chords follow that exactly: base `minadd9`/`min6add9`/`minmaj9`/`min11b5` with `madd9`/`m6add9`/`mmaj9`/`m11b5` aliases pointing at them. This keeps a single source of truth for each interval pattern.
- **Which alias dict.** All new aliases went into `_text_chord_quality_aliases` (lead-sheet text shorthands), not `_ireal_chord_quality_aliases`, which is reserved for iReal Pro's symbolic vocabulary (`^`, `-`, `o`, `h`, `+`). The bare `ø` is a half-diminished text symbol, so it belongs with the text aliases next to the existing `ø7`.
- **`7alt` definition.** The altered dominant is inherently ambiguous (sources disagree on exact tones). Chose the compact, playable voicing `(0,4,8,10,13,15)` — root, 3rd, ♯5/♭13, ♭7, ♭9, ♯9 — which captures the characteristic "altered" sound without expanding to the full 7-note altered scale-chord.

## Behavior change + test update

`chords.py:_simplify_quality_extension` checks `chord_quality` membership *before* stripping alterations. So defining `7b9`, `7#9`, `7b5`, `maj7b5`, `maj7#5`, `m11b5` means the parser now **honors** these instead of reducing them to the base quality (e.g. `C7b9` → `(0,4,7,10,13)` rather than a plain dominant 7). This is the intended consequence.

`tonal/tests/test_chords.py` is updated to match:
- `test_chord_to_notes_simplifies_common_alterations` now uses `A7#11` (an *undefined* alteration → still strips to dominant 7), preserving the original strip-fallback coverage.
- New `test_chord_to_notes_honors_defined_alterations` asserts `A7b9` → 5-note ♭9 chord.

All 9 tests in `test_chords.py` pass.
